### PR TITLE
Removing Environment files from ksonnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 **/audit.log
 **/.DS_Store
 **/*.transformed.yaml
+apps/k8s/ksonnet/myapp/environments/**/
 
 readme.html


### PR DESCRIPTION
**Why:**

* So that people don't accidentally commit their apiservers

Signed-off-by: Christopher Hein <me@christopherhein.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
