### PR TITLE
Issue#49 - ECS Cluster + Deploy task using CloudFormation

### DIFF
--- a/apps/ecs/ec2/templates/greeting.yaml
+++ b/apps/ecs/ec2/templates/greeting.yaml
@@ -1,0 +1,112 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Creating ECS service
+
+Parameters:
+
+  PrivateALB:
+    Type: String
+  ECSCluster:
+    Type: String
+  VPC:
+    Type: String
+  PrivateSubnet1:
+    Type: String
+  PrivateSubnet2:
+    Type: String
+  SecurityGroup:
+    Type: String
+
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /ecs/${AWS::StackName}
+  taskdefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      RequiresCompatibilities:
+        - "EC2"
+      Cpu: 256
+      Memory: 1GB
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: Greeting
+          Cpu: 10
+          Image: arungupta/greeting
+          Memory: 500
+          PortMappings:
+            - ContainerPort: 8081
+          LogConfiguration:
+             LogDriver: awslogs
+             Options:
+               awslogs-group: !Ref LogGroup
+               awslogs-region: !Ref AWS::Region
+               awslogs-stream-prefix: greeting
+
+  service:
+    Type: 'AWS::ECS::Service'
+    DependsOn: listener
+    Properties:
+      Cluster: !Ref ECSCluster
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: EC2
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !Ref SecurityGroup
+          Subnets:
+            - !Ref PrivateSubnet1
+            - !Ref PrivateSubnet2
+      LoadBalancers:
+        - TargetGroupArn: !Ref targetgroup001
+          ContainerPort: 8081
+          ContainerName: Greeting
+      TaskDefinition: !Ref taskdefinition
+      ServiceName: greeting
+
+  targetgroup001:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 60
+      UnhealthyThresholdCount: 10
+      HealthCheckPath: /resources/greeting
+      Name: greeting
+      Port: 8081
+      Protocol: HTTP
+      VpcId: !Ref VPC
+      TargetType: ip
+
+  listener:
+      Type: AWS::ElasticLoadBalancingV2::Listener
+      DependsOn: ECSServiceRole
+      Properties:
+        DefaultActions:
+          - Type: forward
+            TargetGroupArn:
+              Ref: targetgroup001
+        LoadBalancerArn: !Ref PrivateALB
+        Port: 8081
+        Protocol: HTTP
+  ECSServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ['elasticloadbalancing:DeregisterInstancesFromLoadBalancer', 'elasticloadbalancing:DeregisterTargets',
+              'elasticloadbalancing:Describe*', 'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
+              'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
+            Resource: '*'
+
+  

--- a/apps/ecs/ec2/templates/infrastructure.yaml
+++ b/apps/ecs/ec2/templates/infrastructure.yaml
@@ -1,0 +1,408 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating ECS service
+Mappings:
+  AWSRegionToAMI:
+    ap-south-1:
+      AMI: ami-00491f6f
+    eu-west-3:
+      AMI: ami-9aef59e7
+    eu-west-2:
+      AMI: ami-67cbd003
+    eu-west-1:
+      AMI: ami-1d46df64
+    ap-northeast-2:
+      AMI: ami-c212b2ac
+    ap-northeast-1:
+      AMI: ami-872c4ae1
+    sa-east-1:
+      AMI: ami-af521fc3
+    ca-central-1:
+      AMI: ami-435bde27
+    ap-southeast-1:
+      AMI: ami-910d72ed
+    ap-southeast-2:
+      AMI: ami-58bb443a
+    eu-central-1:
+      AMI: ami-509a053f
+    us-east-1:
+      AMI: ami-28456852
+    us-east-2:
+      AMI: ami-ce1c36ab
+    us-west-1:
+      AMI: ami-74262414
+    us-west-2:
+      AMI: ami-decc7fa6
+Resources:
+  VPC:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock: 10.0.0.0/24
+  PrivateSubnet1:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.0/26
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+  PrivateSubnet2:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.64/26
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+  PublicSubnet1:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      MapPublicIpOnLaunch: true
+      CidrBlock: 10.0.0.128/26
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+  PublicSubnet2:
+    Type: 'AWS::EC2::Subnet'
+    Properties:
+      VpcId: !Ref VPC
+      MapPublicIpOnLaunch: true
+      CidrBlock: 10.0.0.192/26
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+  InternetGateway:
+    Type: 'AWS::EC2::InternetGateway'
+  GatewayAttachment:
+    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+  RouteIGW:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  NAT1:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+        - EIP1
+        - AllocationId
+      SubnetId: !Ref PublicSubnet1
+  EIP1:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+  Route1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable1
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT1
+  NAT2:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+        - EIP2
+        - AllocationId
+      SubnetId: !Ref PublicSubnet2
+  EIP2:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+  Route2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NAT2
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+  PrivateRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+  PrivateRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+  RouteTableAssociation1:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref PublicRouteTable
+  RouteTableAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+  RouteTableAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateRouteTable1
+  RouteTableAssociation4:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable2
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+  ALBPublic:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups:
+        - !GetAtt SecurityGroupPublic.GroupId
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+  ALBPrivate:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internal
+      SecurityGroups:
+        - !GetAtt SecurityGroupWebapp.GroupId
+      Subnets:
+        - !Ref PrivateSubnet1
+        - !Ref PrivateSubnet2
+  SecurityGroupPublic:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: ALBPublic
+      GroupDescription: AllowWebTraffic
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+  SecurityGroupWebapp:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: WebAppSecurityGroup
+      GroupDescription: WebAppSecurityGroupRules
+      VpcId: !Ref VPC
+  IngressRuleWebapp:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+      SourceSecurityGroupId: !GetAtt SecurityGroupPublic.GroupId
+      GroupId: !GetAtt SecurityGroupWebapp.GroupId
+  IngressRuleWebapp001:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: 8081
+      ToPort: 8082
+      SourceSecurityGroupId: !GetAtt SecurityGroupWebapp.GroupId
+      GroupId: !GetAtt SecurityGroupWebapp.GroupId
+  PublicECSHostSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties: 
+          VpcId: !Ref VPC
+          GroupDescription: Access to the ECS hosts and the tasks/containers that run on them
+          SecurityGroupIngress:
+                # Only allow inbound access to ECS from the ELB
+              - SourceSecurityGroupId: !Ref SecurityGroupPublic 
+                IpProtocol: -1
+  PrivateECSHostSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties: 
+          VpcId: !Ref VPC
+          GroupDescription: Access to the ECS hosts and the tasks/containers that run on them
+          SecurityGroupIngress:
+                # Only allow inbound access to ECS from the ELB
+              - SourceSecurityGroupId: !Ref SecurityGroupWebapp 
+                IpProtocol: -1
+  ECSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref ECSRole
+  PrivateAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: [!Ref 'PrivateSubnet1']
+      LaunchConfigurationName: !Ref PrivateLaunchConfiguration
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      Tags: 
+        - Key: Name
+          Value: !Sub ${AWS::StackName} - ECS Host
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 1
+        MaxBatchSize: 1
+        PauseTime: PT15M
+        WaitOnResourceSignals: true
+
+  PrivateLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          commands:
+            01_add_instance_to_cluster:
+                command: !Sub echo ECS_CLUSTER=${ECSCluster} > /etc/ecs/ecs.config
+          files:
+            "/etc/cfn/cfn-hup.conf":
+              mode: 000400
+              owner: root
+              group: root
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+            "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.ContainerInstances.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource LaunchConfiguration
+          services:
+            sysvinit:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files:
+                  - /etc/cfn/cfn-hup.conf
+                  - /etc/cfn/hooks.d/cfn-auto-reloader.conf
+    Properties:
+      ImageId: !FindInMap [ AWSRegionToAMI, !Ref "AWS::Region", AMI ]
+      InstanceType: m4.large
+      IamInstanceProfile: !Ref InstanceProfile
+      SecurityGroups:
+        - !Ref PrivateECSHostSecurityGroup
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          yum install -y aws-cfn-bootstrap
+          /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource PrivateLaunchConfiguration
+          /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource PrivateAutoScalingGroup
+   
+  PublicAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      VPCZoneIdentifier: [!Ref 'PublicSubnet1']
+      LaunchConfigurationName: !Ref PublicLaunchConfiguration
+      MinSize: 1
+      MaxSize: 1
+      DesiredCapacity: 1
+      Tags: 
+        - Key: Name
+          Value: !Sub ${AWS::StackName} - ECS Host
+          PropagateAtLaunch: true
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 1
+        MaxBatchSize: 1
+        PauseTime: PT15M
+        WaitOnResourceSignals: true
+
+  PublicLaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Metadata:
+      AWS::CloudFormation::Init:
+        config:
+          commands:
+            01_add_instance_to_cluster:
+                command: !Sub echo ECS_CLUSTER=${ECSCluster} > /etc/ecs/ecs.config
+          files:
+            "/etc/cfn/cfn-hup.conf":
+              mode: 000400
+              owner: root
+              group: root
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+            "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.ContainerInstances.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource LaunchConfiguration
+          services:
+            sysvinit:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files:
+                  - /etc/cfn/cfn-hup.conf
+                  - /etc/cfn/hooks.d/cfn-auto-reloader.conf
+    Properties:
+      ImageId: !FindInMap [ AWSRegionToAMI, !Ref "AWS::Region", AMI ]
+      InstanceType: m4.xlarge
+      KeyName: 'Tapo-Personal'
+      IamInstanceProfile: !Ref InstanceProfile
+      SecurityGroups:
+        - !Ref PublicECSHostSecurityGroup
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          yum install -y aws-cfn-bootstrap
+          /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource PublicLaunchConfiguration
+          /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource PublicAutoScalingGroup  
+Outputs:
+  ECSCluster:
+    Value: !Ref ECSCluster
+  VPC:
+    Value: !Ref VPC
+  PrivateSubnet1:
+    Value: !Ref PrivateSubnet1
+  PrivateSubnet2:
+    Value: !Ref PrivateSubnet2
+  PublicSubnet1:
+    Value: !Ref PublicSubnet1
+  PublicSubnet2:
+    Value: !Ref PublicSubnet2
+  ALBPublic:
+    Value: !Ref ALBPublic
+  ALBPrivate:
+    Value: !Ref ALBPrivate
+  ALBPublicCNAME:
+    Value: !GetAtt ALBPublic.DNSName
+  ALBPrivateCNAME:
+    Value: !GetAtt ALBPrivate.DNSName
+  SecurityGroupWebapp:
+    Value: !GetAtt SecurityGroupWebapp.GroupId
+  PrivateECSHostSecurityGroup:
+    Value: !Ref PrivateECSHostSecurityGroup
+  PublicECSHostSecurityGroup:
+    Value: !Ref PrivateECSHostSecurityGroup

--- a/apps/ecs/ec2/templates/infrastructure.yaml
+++ b/apps/ecs/ec2/templates/infrastructure.yaml
@@ -369,7 +369,6 @@ Resources:
     Properties:
       ImageId: !FindInMap [ AWSRegionToAMI, !Ref "AWS::Region", AMI ]
       InstanceType: m4.xlarge
-      KeyName: 'Tapo-Personal'
       IamInstanceProfile: !Ref InstanceProfile
       SecurityGroups:
         - !Ref PublicECSHostSecurityGroup

--- a/apps/ecs/ec2/templates/master.yaml
+++ b/apps/ecs/ec2/templates/master.yaml
@@ -1,0 +1,43 @@
+Description: >
+  This template illustrates how to use Fargate to deploy a three service microservice architecture.
+Resources:
+
+  Infrastructure:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/aws-compute-options-bucket/infrastructure.yaml
+
+  Greeting:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/aws-compute-options-bucket/greeting.yaml
+      Parameters:
+        PrivateSubnet1: !GetAtt Infrastructure.Outputs.PrivateSubnet1
+        PrivateSubnet2: !GetAtt Infrastructure.Outputs.PrivateSubnet2
+        PrivateALB: !GetAtt Infrastructure.Outputs.ALBPrivate
+        ECSCluster: !GetAtt Infrastructure.Outputs.ECSCluster
+        VPC: !GetAtt Infrastructure.Outputs.VPC
+        SecurityGroup: !GetAtt Infrastructure.Outputs.SecurityGroupWebapp
+  Name:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/aws-compute-options-bucket/name.yaml
+      Parameters:
+        PrivateSubnet1: !GetAtt Infrastructure.Outputs.PrivateSubnet1
+        PrivateSubnet2: !GetAtt Infrastructure.Outputs.PrivateSubnet2
+        PrivateALB: !GetAtt Infrastructure.Outputs.ALBPrivate
+        ECSCluster: !GetAtt Infrastructure.Outputs.ECSCluster
+        VPC: !GetAtt Infrastructure.Outputs.VPC
+        SecurityGroup: !GetAtt Infrastructure.Outputs.SecurityGroupWebapp
+  Webapp:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/aws-compute-options-bucket/webapp.yaml
+      Parameters:
+        PublicSubnet1: !GetAtt Infrastructure.Outputs.PublicSubnet1
+        PublicSubnet2: !GetAtt Infrastructure.Outputs.PublicSubnet2
+        PublicALB: !GetAtt Infrastructure.Outputs.ALBPublic
+        ALBPublicCNAME: !GetAtt Infrastructure.Outputs.ALBPublicCNAME
+        ECSCluster: !GetAtt Infrastructure.Outputs.ECSCluster
+        SecurityGroup: !GetAtt Infrastructure.Outputs.SecurityGroupWebapp
+        VPC: !GetAtt Infrastructure.Outputs.VPC

--- a/apps/ecs/ec2/templates/name.yaml
+++ b/apps/ecs/ec2/templates/name.yaml
@@ -1,0 +1,111 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Creating ECS service
+
+Parameters:
+
+  PrivateALB:
+    Type: String
+  ECSCluster:
+    Type: String
+  VPC:
+    Type: String
+  PrivateSubnet1:
+    Type: String
+  PrivateSubnet2:
+    Type: String
+  SecurityGroup:
+    Type: String
+ 
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /ecs/${AWS::StackName}
+  taskdefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      RequiresCompatibilities:
+        - "EC2"
+      Cpu: 256
+      NetworkMode: awsvpc
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: name
+          Cpu: 10
+          Image: arungupta/name
+          Memory: 500        
+          PortMappings:
+            - ContainerPort: 8082
+          LogConfiguration:
+             LogDriver: awslogs
+             Options:
+               awslogs-group: !Ref LogGroup
+               awslogs-region: !Ref AWS::Region 
+               awslogs-stream-prefix: name  
+  service:
+    Type: 'AWS::ECS::Service'
+    DependsOn: listener
+    Properties:
+      #Role: !Ref ECSServiceRole
+      Cluster: !Ref ECSCluster
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: EC2
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !Ref SecurityGroup
+          Subnets:
+            - !Ref PrivateSubnet1
+            - !Ref PrivateSubnet2
+      LoadBalancers:
+        - TargetGroupArn: !Ref targetgroup000
+          ContainerPort: 8082
+          ContainerName: name
+      TaskDefinition: !Ref taskdefinition
+      ServiceName: name
+
+  targetgroup000:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 60
+      UnhealthyThresholdCount: 10
+      HealthCheckPath: /resources/names/1
+      Name: name
+      Port: 8082
+      Protocol: HTTP
+      VpcId: !Ref VPC
+      TargetType: ip
+
+  listener:
+      Type: AWS::ElasticLoadBalancingV2::Listener
+      DependsOn: ECSServiceRole
+      Properties:
+        DefaultActions:
+          - Type: forward
+            TargetGroupArn:
+              Ref: targetgroup000
+        LoadBalancerArn: !Ref PrivateALB
+        Port: 8082
+        Protocol: HTTP
+  ECSServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ['elasticloadbalancing:DeregisterInstancesFromLoadBalancer', 'elasticloadbalancing:DeregisterTargets',
+              'elasticloadbalancing:Describe*', 'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
+              'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
+            Resource: '*'
+ 

--- a/apps/ecs/ec2/templates/script.sh
+++ b/apps/ecs/ec2/templates/script.sh
@@ -1,0 +1,1 @@
+aws s3 cp . s3://aws-compute-options/ --recursive --acl public-read

--- a/apps/ecs/ec2/templates/webapp.yaml
+++ b/apps/ecs/ec2/templates/webapp.yaml
@@ -1,0 +1,126 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Creating ECS service
+
+Parameters:
+
+  ECSCluster:
+    Type: String
+  VPC:
+    Type: String
+  PublicALB:
+    Type: String
+  ALBPrivateCNAME:
+    Type: String
+  PublicSubnet1:
+    Type: String
+  PublicSubnet2:
+    Type: String
+  SecurityGroup:
+    Type: String
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /ecs/${AWS::StackName}
+  taskdefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      RequiresCompatibilities:
+        - "EC2"
+      Cpu: 256
+      NetworkMode: awsvpc
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: webapp
+          Cpu: 10
+          Environment:
+            - Name: NAME_SERVICE_HOST
+              Value: !Ref ALBPrivateCNAME
+            - Name: NAME_SERVICE_PORT
+              Value: "8082"
+            - Name: NAME_SERVICE_PATH
+              Value: /resources/names/1
+            - Name: GREETING_SERVICE_HOST
+              Value: !Ref ALBPrivateCNAME
+            - Name: GREETING_SERVICE_PORT
+              Value: "8081"
+            - Name: GREETING_SERVICE_PATH
+              Value: /resources/greeting
+          Image: arungupta/webapp
+          Memory: 500
+          PortMappings:
+            - ContainerPort: 8080  
+          LogConfiguration:
+             LogDriver: awslogs
+             Options:
+               awslogs-group: !Ref LogGroup
+               awslogs-region: !Ref AWS::Region
+               awslogs-stream-prefix: webapp
+
+  service:
+    Type: 'AWS::ECS::Service'
+    DependsOn: listener
+    Properties:
+      Cluster: !Ref ECSCluster
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: EC2
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !Ref SecurityGroup
+          Subnets:
+            - !Ref PublicSubnet1
+            - !Ref PublicSubnet2
+      LoadBalancers:
+        - TargetGroupArn: !Ref targetgroup002
+          ContainerPort: 8080
+          ContainerName: webapp
+      TaskDefinition: !Ref taskdefinition
+      ServiceName: webapp
+
+  targetgroup002:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 60
+      UnhealthyThresholdCount: 10
+      HealthCheckPath: /
+      Name: webapp
+      Port: 8080
+      Protocol: HTTP
+      VpcId: !Ref VPC
+      TargetType: ip
+
+  listener:
+      Type: AWS::ElasticLoadBalancingV2::Listener
+      DependsOn: ECSServiceRole
+      Properties:
+        DefaultActions:
+          - Type: forward
+            TargetGroupArn:
+              Ref: targetgroup002
+        LoadBalancerArn: !Ref PublicALB
+        Port: 80
+        Protocol: HTTP
+  ECSServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: ecs-service
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ['elasticloadbalancing:DeregisterInstancesFromLoadBalancer', 'elasticloadbalancing:DeregisterTargets',
+              'elasticloadbalancing:Describe*', 'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
+              'elasticloadbalancing:RegisterTargets', 'ec2:Describe*', 'ec2:AuthorizeSecurityGroupIngress']
+            Resource: '*'
+
+  

--- a/readme.adoc
+++ b/readme.adoc
@@ -106,6 +106,25 @@ Retrieve the public endpoint to test your application deployment:
 
 == Deploy Application to Amazon ECS
 
+
+=== CloudFormation only
+
+|===
+|Region | Launch Template
+| *N. Virginia* (us-east-1)
+a| image::./images/deploy-to-aws.png[link=https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=aws-compute-options-ecs&templateURL=https://s3.amazonaws.com/aws-compute-options/master.yaml]
+|===
+
+Retrieve the public endpoint to test your application deployment:
+
+```
+    aws cloudformation \
+        describe-stacks \
+        --stack-name aws-compute-options-ecs \
+        --query "Stacks[].Outputs[?OutputKey=='PublicALBCNAME'.[OutputValue]]" \
+        --output text
+```
+
 === Console and ECS CLI
 
 === CloudFormation and ECS CLI

--- a/readme.adoc
+++ b/readme.adoc
@@ -112,7 +112,7 @@ Retrieve the public endpoint to test your application deployment:
 |===
 |Region | Launch Template
 | *N. Virginia* (us-east-1)
-a| image::./images/deploy-to-aws.png[link=https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=aws-compute-options-ecs&templateURL=https://s3.amazonaws.com/aws-compute-options/master.yaml]
+a| image::./images/deploy-to-aws.png[link=https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=aws-compute-options-ecs&templateURL=https://s3.amazonaws.com/aws-compute-options-bucket/master.yaml]
 |===
 
 Retrieve the public endpoint to test your application deployment:


### PR DESCRIPTION
*Issue #, if available: 49

*Description of changes:*


The master yaml creates infrastructure (VPC, Network, ASG, Security Groups, ALB) and then calls nested templates for creating webapp, name and greeting service. After successful deployment one should see this curling the Public ALB endpoint. 

`curl http://demo-XXXXXXXXXX-1xxxxxxxxxx1.<Region>.elb.amazonaws.com
Hello Sheldon`

CloudWatch logs for webapp should show something like this:

`2018-03-08 18:55:21,973 INFO [stdout] (default task-11) GREETING endpoint: http://internal-simpl-xxxxxxxxxx-11111111111.<Region>.elb.amazonaws.com:8081/resources/greeting`

`2018-03-08 18:55:21,974 INFO [stdout] (default task-11) NAME endpoint: http://internal-simpl-xxxxxxxxxx-11111111111.<Region>.elb.amazonaws.com:8082/resources/names/1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
